### PR TITLE
feat: add command abbreviation support

### DIFF
--- a/mrblib/00magni/error.rb
+++ b/mrblib/00magni/error.rb
@@ -13,6 +13,12 @@ class Magni
     end
   end
 
+  class AmbiguousCommandError < Error
+    def initialize(input, matches)
+      super("Ambiguous command '#{input}': #{matches.join(', ')}")
+    end
+  end
+
   class CommandArgumentError < Error
     def initialize(command, message)
       super("#{command.name}: #{message}")

--- a/test/magni/base/dispatcher.rb
+++ b/test/magni/base/dispatcher.rb
@@ -16,7 +16,7 @@ assert('Magni::Base::Dispatcher#using_default? returns false by default and true
   end
   obj = klass.new
   assert_false obj.using_default?
-  obj.fallback_default_command(klass)
+  obj.__send__(:fallback_default_command, klass)
   assert_true obj.using_default?
 end
 
@@ -56,6 +56,53 @@ assert('Magni::Base::Dispatcher#select_command') do
     assert_nil cmd
     assert_equal ['-h', 'foo'], argv
   end
+
+  assert('supports command abbreviation') do
+    klass = Class.new do
+      include Magni::Base::Dispatcher
+
+      def self.commands = { execute: :executecmd, start: :startcmd, help: :helpcmd }
+    end
+    obj = klass.new
+
+    # Exact match takes precedence
+    cmd, argv = obj.select_command(%w[execute arg1], klass)
+    assert_equal :executecmd, cmd
+    assert_equal ['arg1'], argv
+
+    # Single character abbreviation
+    cmd, argv = obj.select_command(%w[e arg1], klass)
+    assert_equal :executecmd, cmd
+    assert_equal ['arg1'], argv
+
+    # Partial abbreviation
+    cmd, argv = obj.select_command(%w[exec arg1], klass)
+    assert_equal :executecmd, cmd
+    assert_equal ['arg1'], argv
+
+    # Different single character
+    cmd, argv = obj.select_command(%w[s arg1], klass)
+    assert_equal :startcmd, cmd
+    assert_equal ['arg1'], argv
+
+    # Another single character
+    cmd, argv = obj.select_command(%w[h arg1], klass)
+    assert_equal :helpcmd, cmd
+    assert_equal ['arg1'], argv
+  end
+
+  assert('raises error for ambiguous abbreviation') do
+    klass = Class.new do
+      include Magni::Base::Dispatcher
+
+      def self.commands = { execute: :executecmd, exit: :exitcmd }
+    end
+    obj = klass.new
+
+    assert_raise(Magni::AmbiguousCommandError) do
+      obj.select_command(['ex'], klass)
+    end
+  end
 end
 
 assert('Magni::Base::Dispatcher#fallback_default_command') do
@@ -67,7 +114,7 @@ assert('Magni::Base::Dispatcher#fallback_default_command') do
       def self.commands = { foo: :foocmd }
     end
     obj = klass.new
-    cmd = obj.fallback_default_command(klass)
+    cmd = obj.__send__(:fallback_default_command, klass)
     assert_equal :foocmd, cmd
   end
 
@@ -79,8 +126,70 @@ assert('Magni::Base::Dispatcher#fallback_default_command') do
       def self.commands = {}
     end
     obj = klass.new
-    cmd = obj.fallback_default_command(klass)
+    cmd = obj.__send__(:fallback_default_command, klass)
     assert_nil cmd
+  end
+end
+
+assert('Magni::Base::Dispatcher#find_command_by_abbreviation') do
+  assert('returns command for exact abbreviation match') do
+    klass = Class.new do
+      include Magni::Base::Dispatcher
+    end
+    obj = klass.new
+    commands = { execute: :executecmd, start: :startcmd, help: :helpcmd }
+
+    # Single character match
+    cmd = obj.__send__(:find_command_by_abbreviation, 'e', commands)
+    assert_equal :executecmd, cmd
+
+    # Partial match
+    cmd = obj.__send__(:find_command_by_abbreviation, 'exec', commands)
+    assert_equal :executecmd, cmd
+
+    # Different single character
+    cmd = obj.__send__(:find_command_by_abbreviation, 's', commands)
+    assert_equal :startcmd, cmd
+  end
+
+  assert('returns nil for no match') do
+    klass = Class.new do
+      include Magni::Base::Dispatcher
+    end
+    obj = klass.new
+    commands = { execute: :executecmd, start: :startcmd }
+
+    cmd = obj.__send__(:find_command_by_abbreviation, 'z', commands)
+    assert_nil cmd
+  end
+
+  assert('raises error for ambiguous abbreviation') do
+    klass = Class.new do
+      include Magni::Base::Dispatcher
+    end
+    obj = klass.new
+    commands = { execute: :executecmd, exit: :exitcmd }
+
+    assert_raise(Magni::AmbiguousCommandError) do
+      obj.__send__(:find_command_by_abbreviation, 'ex', commands)
+    end
+  end
+
+  assert('error message contains all matching commands') do
+    klass = Class.new do
+      include Magni::Base::Dispatcher
+    end
+    obj = klass.new
+    commands = { execute: :executecmd, exit: :exitcmd, export: :exportcmd }
+
+    begin
+      obj.__send__(:find_command_by_abbreviation, 'ex', commands)
+      assert_true false, 'Expected Magni::AmbiguousCommandError to be raised'
+    rescue Magni::AmbiguousCommandError => e
+      assert_true e.message.include?('execute')
+      assert_true e.message.include?('exit')
+      assert_true e.message.include?('export')
+    end
   end
 end
 

--- a/test/magni/error.rb
+++ b/test/magni/error.rb
@@ -16,6 +16,12 @@ assert('Magni::CommandNotFoundError initializes with correct message') do
   assert_true err.is_a?(Magni::Error)
 end
 
+assert('Magni::AmbiguousCommandError initializes with correct message') do
+  err = Magni::AmbiguousCommandError.new('ex', %w[execute exit])
+  assert_equal "Ambiguous command 'ex': execute, exit", err.message
+  assert_true err.is_a?(Magni::Error)
+end
+
 assert('Magni::CommandArgumentError initializes with correct message') do
   command = Struct.new(:name).new('build')
   err = Magni::CommandArgumentError.new(command, 'missing target')
@@ -58,6 +64,7 @@ assert('All error classes inherit from Magni::Error') do
   errors = [
     Magni::RequiredOptionError.new('test'),
     Magni::CommandNotFoundError.new('test'),
+    Magni::AmbiguousCommandError.new('test', %w[cmd1 cmd2]),
     Magni::CommandArgumentError.new(Struct.new(:name).new('test'), 'msg'),
     Magni::OptionTypeInvalidError.new('test'),
     Magni::InvalidFormatError.new,


### PR DESCRIPTION
Allow commands to be executed using abbreviations like 'e' for 'execute'. Includes ambiguity detection and comprehensive test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)